### PR TITLE
Parsing properly

### DIFF
--- a/src/main/scala/Listing.scala
+++ b/src/main/scala/Listing.scala
@@ -1,0 +1,16 @@
+/**
+  * Created by luisguerrero on 2/14/17.
+  */
+case class Listing(id: String, pageTitle: String, action: Option[String], name: Option[String], location_0_coordinate: Option[Double],
+                   location_1_coordinate: Option[Double], location: Option[String], content: Option[String])
+
+object Listing {
+  def apply(page: String) = new Listing(java.util.UUID.randomUUID.toString,page, None, None, None, None, None, None)
+
+  def apply(page: String, map: Map[String, Option[String]]) = new Listing(java.util.UUID.randomUUID.toString,page,
+    map("action"), map("name"), try { Some(map("lat").getOrElse("0").filterNot((x: Char) => x.isWhitespace).toDouble) }
+    catch { case _ => None }, try { Some(map("long").getOrElse("0").filterNot((x: Char) => x.isWhitespace).toDouble) }
+    catch { case _ => None }, {val location = (map("lat").getOrElse("").filterNot((x: Char) => x.isWhitespace) + "," +
+      map("long").getOrElse("").filterNot((x: Char) => x.isWhitespace)); if(location.startsWith(",") || location.endsWith(","))
+      None else Some(location)}, map("content"))
+}

--- a/src/main/scala/TextParser.scala
+++ b/src/main/scala/TextParser.scala
@@ -1,0 +1,45 @@
+import scala.collection.immutable.Nil
+
+/**
+  * Created by luisguerrero on 2/14/17.
+  */
+trait TextParser {
+
+  def parseText(text: String): List[String] = {
+    if(text.isEmpty) Nil
+    else {
+      val (newText,index) = extractInnerExpression(text,"{{","}}")
+      newText.replaceAll("\n","") :: parseText(text.substring(index))
+    }
+  }
+
+  def subStrings(pattern: String, str: String) = {
+    def subStrings(str: String, offset: Int): Stream[(Int,String)] = {
+      val index = str.indexOf(pattern)
+      if (index < 0) Stream.empty
+      else {
+        val slice = index + pattern.size
+        Stream.cons((offset + slice, str.substring(slice)),subStrings(str.substring(slice),offset + slice))
+      }
+    }
+    subStrings(str,0)
+  }
+
+  def extractInnerExpression(text: String, start: String, end: String): (String,Int) = {
+    def findMatch(start: Stream[(Int,String)], end: Stream[(Int,String)], acc: Int): Int = {
+      if(end.isEmpty) text.size
+      else if(start.isEmpty && acc == 1) end.head._1
+      else if(start.isEmpty) findMatch(start,end.tail,acc-1)
+      else if(start.head._1 < end.head._1) findMatch(start.tail,end,acc+1)
+      else if(start.head._1 > end.head._1 && acc != 1) findMatch(start,end.tail,acc-1)
+      else end.head._1
+    }
+    val starts = subStrings(start,text)
+    val ends = subStrings(end,text)
+    val matchIndex = findMatch(starts,ends,0)
+
+    if(matchIndex != text.size)
+      (text.substring(starts.head._1 - start.size,matchIndex),matchIndex)
+    else ("",text.size)
+  }
+}

--- a/src/main/scala/WikiMediaListing.scala
+++ b/src/main/scala/WikiMediaListing.scala
@@ -26,9 +26,10 @@ trait WikiMediaListing extends RegexParsers {
       case x ~ "=" ~ y1 ~ z ~ y2 => (x, Some(y1.getOrElse("") + z.getOrElse(("",""))._1 + y2.getOrElse("")))
   }
 
-  def innerPair: Parser[(String, String)] = ("{{"|"[[") ~ text ~ "|" ~ text ~ ("}}"|"]]") ^^ {
+  def innerPair: Parser[(String, String)] = ("{{"|"[[") ~ text ~ opt("|") ~ text ~ ("}}"|"]]") ^^ {
     {
-      case (("{{"|"[[") ~ x ~ "|" ~ y ~ ("}}"|"]]")) => (x, y)
+      case (("{{"|"[[") ~ x ~ Some("|") ~ y ~ ("}}"|"]]")) => (x, y)
+      case (("{{"|"[[") ~ x ~ None ~ y ~ ("}}"|"]]")) => (x, y)
     }
   }
   

--- a/src/main/scala/WikiMediaListing.scala
+++ b/src/main/scala/WikiMediaListing.scala
@@ -1,0 +1,42 @@
+import scala.util.matching.Regex
+import scala.util.parsing.combinator.{RegexParsers, SubSequence}
+import scala.util.parsing.combinator
+import scala.util.parsing.combinator.syntactical.StandardTokenParsers
+
+/**
+  * Created by luisguerrero
+  */
+trait WikiMediaListing extends RegexParsers {
+  override def skipWhitespace = true
+
+  def listing(page: String): Parser[Listing] = "{{" ~ name ~ "|" ~ repsep(pair2, "|") ~ "}}" ^^ {
+    {
+      case "{{" ~ name ~ "|" ~ mp ~ "}}" => Listing(page,
+        (Map("action" -> Some(name)).withDefaultValue(None) ++ mp.map(x => (x._1,x._2))))
+    }
+  }
+
+  def pair: Parser[(String, Option[String])] = attr ~ "=" ~
+    opt(text) ^^ {
+    case x ~ "=" ~ y => (x,y)
+  }
+
+  def pair2: Parser[(String, Option[String])] = attr ~ "=" ~
+    opt(text) ~ opt(innerPair) ~ opt(text) ^^ {
+      case x ~ "=" ~ y1 ~ z ~ y2 => (x, Some(y1.getOrElse("") + z.getOrElse(("",""))._1 + y2.getOrElse("")))
+  }
+
+  def innerPair: Parser[(String, String)] = ("{{"|"[[") ~ text ~ "|" ~ text ~ ("}}"|"]]") ^^ {
+    {
+      case (("{{"|"[[") ~ x ~ "|" ~ y ~ ("}}"|"]]")) => (x, y)
+    }
+  }
+  
+  def name: Parser[String] = ("see" | "do")
+
+  def attr: Parser[String] = ("checkin" | "checkout" | "name" | "alt" | "email" | "url" | "address" | "lat" | "long" | "wikidata" |
+    "directions" | "phone" | "tollfree" | "fax" | "hours" | "price" | "lastedit" | "content" | "wikipedia" | "image")
+
+  def text: Parser[String] = """[^\||\{\{|\}\}|\[\[|\]\]]+?(?=(\r|\n|\||\{\{|\}\}|\[\[|\]\]|$))""".r | ""
+
+}

--- a/src/test/scala/WikiMediaParserSpec.scala
+++ b/src/test/scala/WikiMediaParserSpec.scala
@@ -6,11 +6,10 @@ import org.scalatest.{FlatSpec, Matchers}
 class WikiMediaParserSpec  extends FlatSpec with Matchers with WikiMediaListing {
 
   it should "parse a simple wikimedia listing properly" in {
-      val txt = """see| name=Split Point Lighthouse | content =  Affectionately known as The White Queen"""
+    val txt = """{{see| name=Split Point Lighthouse | content =  Affectionately known as The White Queen}}"""
 
-      val lst: Listing = parseAll(listing("whatever"),txt).getOrElse(Listing("whatever"))
-    
-    
+    val lst: Listing = parseAll(listing("whatever"),txt).getOrElse(Listing("whatever"))
+
     lst.copy(id="") should equal (Listing("whatever", Map("action" -> Some("see"),
       "name" -> Some("Split Point Lighthouse "), "lat" -> None,
       "long" -> None, "location" -> None,
@@ -18,12 +17,10 @@ class WikiMediaParserSpec  extends FlatSpec with Matchers with WikiMediaListing 
   }
 
   it should "parse a simple wikimedia listing with url and dead link properly" in {
-    val txt =
-      """see| name=Split Point Lighthouse | url=http://www.isbryderen-elbjorn.dk {{dead link|May 2016}} |
-        |content =  Affectionately known as The White Queen""".stripMargin
+    val txt = """{{see| name=Split Point Lighthouse | url=http://www.isbryderen-elbjorn.dk {{dead link|May 2016}} |
+        |content =  Affectionately known as The White Queen}}""".stripMargin
 
     val lst: Listing = parseAll(listing("whatever"),txt).getOrElse(Listing("whatever"))
-
 
     lst.copy(id="") should equal (Listing("whatever", Map("action" -> Some("see"),
       "name" -> Some("Split Point Lighthouse "), "lat" -> None,
@@ -35,42 +32,94 @@ class WikiMediaParserSpec  extends FlatSpec with Matchers with WikiMediaListing 
   it should "parse an url pair" in {
     val txt = """url=http://www.isbryderen-elbjorn.dk {{dead link|May 2016}} """
 
-    val pr = parseAll(pair, txt).getOrElse(None)
+    val pr = parseAll(pair2, txt).getOrElse(None)
+
+    pr should equal (("url",Some("http://www.isbryderen-elbjorn.dk dead link")))
+  }
+
+  it should "parse content with inner" in {
+    val txt =
+      """content=There are many temples in and around Almora.One can visit
+        | '''Chitai Temple''', 8 km from city, and a group of temples in
+        | [[Jageshwar | Jageshwar]] (20 km from Almora).""".stripMargin.replaceAll("\n", "")
+
+    val pr = parseAll(pair2, txt).get
+    
+    pr should equal (("content", Some(
+      """There are many temples in and around Almora.One can visit
+        | '''Chitai Temple''', 8 km from city, and a group of temples in Jageshwar
+        | (20 km from Almora).""".stripMargin.replaceAll("\n", ""))))
+  }
 
 
-    pr should equal (("url",Some("http://www.isbryderen-elbjorn.dk "),Some(("dead link","May 2016"))))
+  it should "parse realistic listing" in {
+    val txt = """{{see
+                || name=Saint John's Cathedral | alt=Sint Jans Kathedraal | url= | email=
+                || address= | lat=51.68808 | long=5.30814 | directions=
+                || phone= | tollfree= | fax=
+                || hours= | price=
+                || lastedit=2016-01-25
+                || content=one of the most prominent landmarks of Den Bosch. Building started in 1380,
+                | in Gothic style. The exterior of the building had been deteriorating fast due to acid
+                | rain and restoration works started in 1960. It has taken many years to restore the
+                | full church, but the works are completed and the church can be seen in all its glory.
+                | The restoration also included the interior. Of course some minor maintainance takes
+                | place constantly.
+                |}}""".stripMargin.replaceAll("\n", "")
+
+    val lst = parseAll(listing("whatever"), txt).getOrElse(Listing("whatever"))
+
+    lst.copy(id="") should equal (Listing("","whatever",Some("see"),Some("Saint John's Cathedral "),
+      Some(51.68808),Some(5.30814),Some("51.68808,5.30814"),Some(
+        """one of the most prominent landmarks of Den Bosch. Building started in 1380,
+          | in Gothic style. The exterior of the building had been deteriorating fast
+          | due to acid rain and restoration works started in 1960. It has taken many
+          | years to restore the full church, but the works are completed and the
+          | church can be seen in all its glory. The restoration also included the
+          | interior. Of course some minor maintainance takes place constantly.""".stripMargin.replaceAll("\n", ""))))
+  }
+
+  it should "parse a second realistic listing" in {
+    val txt = """{{see
+                || name=Alnwick Castle | alt= | url=http://www.alnwickcastle.com/ | email=
+                || address= | lat=55.41575 | long=-1.70607 | directions=
+                || phone= | tollfree= | fax=
+                || hours= | price=
+                || wikipedia=Alnwick Castle
+                || content=The &quot;poison garden&quot; tour is entertaining. Seeing the
+                | castle might be a thrill for people who are really big fans of Rowan
+                | Atkinson's &quot;Black Adder&quot; or the Harry Potter films.
+                |}} """.stripMargin.replaceAll("\n", "")
+
+    val lst = parseAll(listing("whatever"), txt).getOrElse(Listing("whatever"))
+
+    lst.copy(id="") should equal (Listing("","whatever",Some("see"),Some("Alnwick Castle "),
+      Some(55.41575),Some(-1.70607),Some("55.41575,-1.70607"),Some(
+        """The &quot;poison garden&quot; tour is entertaining. Seeing the castle might be a thrill
+          | for people who are really big fans of Rowan Atkinson's &quot;Black Adder&quot; or the
+          | Harry Potter films.""".stripMargin.replaceAll("\n", ""))))
+  }
+
+  it should "parse a third realistic listing" in {
+    val txt =
+      """{{see| name=Temples Nearby | url= | email=| address= | lat= | long= |
+        | directions=| phone= | tollfree= | fax=| hours= | price=| content=There
+        | are many temples in and around Almora. One can visit '''Chitai Temple''',
+        | 8 km from city, and a group of temples in [[Jageshwar|Jageshwar]]
+        | (20 km from Almora).}}""".stripMargin.replaceAll("\n", "")
+
+    val lst = parseAll(listing("whatever"), txt).getOrElse(Listing("whatever"))
+
+    lst.copy(id="") should equal (Listing("","whatever",Some("see"),Some("Temples Nearby "),
+      None,None,None,
+      Some("""There are many temples in and around Almora. One can visit '''Chitai Temple''',
+        | 8 km from city, and a group of temples in Jageshwar(20 km from Almora)."""
+        .stripMargin.replaceAll("\n", ""))))
+  }
+
+  it should "get a stream" in {
+    val txt = "{{ this is {{ a test {{ to catch }} substrings }} and match }} }} brackets"
+    WikiMediaParser.extractInnerExpression(txt,"{{","}}")
   }
 }
-
-  //Listing(id: String, pageTitle: String, action: Option[String], name: Option[String], location_0_coordinate: Option[Double],
-  //  location_1_coordinate: Option[Double], location: Option[String], content: Option[String])
-
-  /*it should "parse a more complex wikimedia listing properly" in {
-    val txt =
-      """see| name = Saint John's Cathedral | alt=Sint Jans Kathedraal | url = | email = | address = | lat = 51.68808 |
-        | long=5.30814 | directions= | phone= | tollfree = | fax = | hours = | price=| lastedit=2016-01-25 |
-        | content=one of the most prominent landmarks of Den Bosch. Building started in 1380, in Gothic style.
-        | The exterior of the building had been deteriorating fast due to acid rain and restoration works started
-        | in 1960. It has taken many years to restore the full church, but the works are completed and the church
-        | can be seen in all its glory. The restoration also included the interior. Of course some minor maintainance
-        | takes place constantly.""".stripMargin
-
-    parseAll(listing("whatever"),txt).get should equal (Listing("whatever",Some("see"),Some("Saint John's Cathedral"),
-      Some("51.68808"),Some("51.68808"),Some("""one of the most prominent landmarks of Den Bosch. Building started in 1380, in Gothic style.
-                                                |The exterior of the building had been deteriorating fast due to acid rain and restoration works started
-                                                |in 1960. It has taken many years to restore the full church, but the works are completed and the church
-                                                |can be seen in all its glory. The restoration also included the interior. Of course some minor maintainance
-                                                |takes place constantly.""".stripMargin)))
-  }
-
-  it should "parse a wikimedia listing with urls properly" in {
-    val txt ="""do| name=Elbjørn | url=http://www.isbryderen-elbjorn.dk | email=info@isbryderen-elbjorn.dk|
-        | address= | lat= | long= | directions=| phone= | tollfree= | fax=| hours= | price=| content=Icebreaker
-        | now working as a restaurant and culture ship at the Aalborg harbour. It has a restaurant, a bar, glass
-        | workshop, and a museum.""".stripMargin
-
-    parseAll(listing("whatever"),txt).get should equal (Listing("whatever",Some("see"),Some("Elbjørn"),
-      None,None,Some("""Icebreaker now working as a restaurant and culture ship at the Aalborg harbour. It has a restaurant, a bar, glass
-                       | workshop, and a museum.""".stripMargin))) */
-  
 

--- a/src/test/scala/WikiMediaParserSpec.scala
+++ b/src/test/scala/WikiMediaParserSpec.scala
@@ -8,6 +8,69 @@ class WikiMediaParserSpec  extends FlatSpec with Matchers with WikiMediaListing 
   it should "parse a simple wikimedia listing properly" in {
       val txt = """see| name=Split Point Lighthouse | content =  Affectionately known as The White Queen"""
 
-      parseAll(listing("whatever"),txt).get.content should equal (Some("Affectionately known as The White Queen"))
+      val lst: Listing = parseAll(listing("whatever"),txt).getOrElse(Listing("whatever"))
+    
+    
+    lst.copy(id="") should equal (Listing("whatever", Map("action" -> Some("see"),
+      "name" -> Some("Split Point Lighthouse "), "lat" -> None,
+      "long" -> None, "location" -> None,
+      "content" -> Some("Affectionately known as The White Queen"))).copy(id=""))
+  }
+
+  it should "parse a simple wikimedia listing with url and dead link properly" in {
+    val txt =
+      """see| name=Split Point Lighthouse | url=http://www.isbryderen-elbjorn.dk {{dead link|May 2016}} |
+        |content =  Affectionately known as The White Queen""".stripMargin
+
+    val lst: Listing = parseAll(listing("whatever"),txt).getOrElse(Listing("whatever"))
+
+
+    lst.copy(id="") should equal (Listing("whatever", Map("action" -> Some("see"),
+      "name" -> Some("Split Point Lighthouse "), "lat" -> None,
+      "long" -> None, "location" -> None,
+      "content" -> Some("Affectionately known as The White Queen"))).copy(id=""))
+  }
+
+
+  it should "parse an url pair" in {
+    val txt = """url=http://www.isbryderen-elbjorn.dk {{dead link|May 2016}} """
+
+    val pr = parseAll(pair, txt).getOrElse(None)
+
+
+    pr should equal (("url",Some("http://www.isbryderen-elbjorn.dk "),Some(("dead link","May 2016"))))
   }
 }
+
+  //Listing(id: String, pageTitle: String, action: Option[String], name: Option[String], location_0_coordinate: Option[Double],
+  //  location_1_coordinate: Option[Double], location: Option[String], content: Option[String])
+
+  /*it should "parse a more complex wikimedia listing properly" in {
+    val txt =
+      """see| name = Saint John's Cathedral | alt=Sint Jans Kathedraal | url = | email = | address = | lat = 51.68808 |
+        | long=5.30814 | directions= | phone= | tollfree = | fax = | hours = | price=| lastedit=2016-01-25 |
+        | content=one of the most prominent landmarks of Den Bosch. Building started in 1380, in Gothic style.
+        | The exterior of the building had been deteriorating fast due to acid rain and restoration works started
+        | in 1960. It has taken many years to restore the full church, but the works are completed and the church
+        | can be seen in all its glory. The restoration also included the interior. Of course some minor maintainance
+        | takes place constantly.""".stripMargin
+
+    parseAll(listing("whatever"),txt).get should equal (Listing("whatever",Some("see"),Some("Saint John's Cathedral"),
+      Some("51.68808"),Some("51.68808"),Some("""one of the most prominent landmarks of Den Bosch. Building started in 1380, in Gothic style.
+                                                |The exterior of the building had been deteriorating fast due to acid rain and restoration works started
+                                                |in 1960. It has taken many years to restore the full church, but the works are completed and the church
+                                                |can be seen in all its glory. The restoration also included the interior. Of course some minor maintainance
+                                                |takes place constantly.""".stripMargin)))
+  }
+
+  it should "parse a wikimedia listing with urls properly" in {
+    val txt ="""do| name=Elbjørn | url=http://www.isbryderen-elbjorn.dk | email=info@isbryderen-elbjorn.dk|
+        | address= | lat= | long= | directions=| phone= | tollfree= | fax=| hours= | price=| content=Icebreaker
+        | now working as a restaurant and culture ship at the Aalborg harbour. It has a restaurant, a bar, glass
+        | workshop, and a museum.""".stripMargin
+
+    parseAll(listing("whatever"),txt).get should equal (Listing("whatever",Some("see"),Some("Elbjørn"),
+      None,None,Some("""Icebreaker now working as a restaurant and culture ship at the Aalborg harbour. It has a restaurant, a bar, glass
+                       | workshop, and a museum.""".stripMargin))) */
+  
+

--- a/src/test/scala/WikiMediaParserSpec.scala
+++ b/src/test/scala/WikiMediaParserSpec.scala
@@ -117,6 +117,46 @@ class WikiMediaParserSpec  extends FlatSpec with Matchers with WikiMediaListing 
         .stripMargin.replaceAll("\n", ""))))
   }
 
+  it should "parse listing when name has inner 'pair' with only one member" in  {
+    val txt =
+      """{{do| name= ''Prašivá'' or ''Veľká Chocuľa'' peaks in [[Low Tatras]] |
+        | alt= | url= | email=| address= | lat=48.8938 | long=19.3310 |
+        | directions=Start in ''Liptovská Lúžna'' or ''Korytnica''| phone= |
+        | tollfree= | fax=| hours= | price=| lastedit=2016-11-10|
+        | content=The hike up is quite steep for an hour or two.}}""".stripMargin.replaceAll("\n", "")
+
+    val lst = parseAll(listing("whatever"), txt).getOrElse(Listing("whatever"))
+
+    lst.copy(id="") should equal (Listing("","whatever",Some("do"),
+      Some("""''Prašivá'' or ''Veľká Chocuľa'' peaks in Low Tatras"""),
+      Some(48.8938),Some(19.3310),Some("48.8938,19.3310"),
+      Some("""The hike up is quite steep for an hour or two."""
+        .stripMargin.replaceAll("\n", ""))))
+
+  }
+
+  it should "parse listing when there are multiple inner 'pairs' with only one member in an entity" in {
+
+    val txt =
+      """{{see| name=Gedung Pakuan | alt=Huis van de Resident | url= | email=| address=Jl. Cicendo No 1 |
+        |lat=-6.911792 | long=107.604771 | directions=northern end of Jl. Otto Iskandardinata| phone= |
+        |tollfree= | fax=| hours= | price=| lastedit=2016-12-07| content=Built 1864-1867 as the new
+        |residence of the resident of the residency of [[Parahyangan]], as its capital was moved
+        |from [[Cianjur]] to Bandung. The Indies Empire style building is nowadays used as the
+        |official residence of the governor of West Java province.}}""".stripMargin.replaceAll("\n", "")
+
+    val lst = parseAll(listing("whatever"), txt).getOrElse(Listing("whatever"))
+
+    lst.copy(id="") should equal (Listing("","whatever",Some("see"),
+      Some("Gedung Pakuan"),
+      Some(-6.911792),Some(107.604771),Some("-6.911792,107.604771"),
+      Some("""Built 1864-1867 as the new
+             |residence of the resident of the residency of Parahyangan, as its capital was moved
+             |from Cianjur to Bandung. The Indies Empire style building is nowadays used as the
+             |official residence of the governor of West Java province.""".stripMargin.replaceAll("\n", ""))))
+
+  }
+
   it should "get a stream" in {
     val txt = "{{ this is {{ a test {{ to catch }} substrings }} and match }} }} brackets"
     WikiMediaParser.extractInnerExpression(txt,"{{","}}")


### PR DESCRIPTION
Relying only on parser combinator to parse string in text element the way different listings are extracted is now done using a recursive function using streams instead of using regular expressions which did not account for all cases where there were 'inner' expressions with brackets inside a listing